### PR TITLE
Pad data even if aligned

### DIFF
--- a/src/pkcs7.js
+++ b/src/pkcs7.js
@@ -1,11 +1,7 @@
 function pad (messageLength, blocksize) {
   if (blocksize > 256) throw new Error('can\'t pad blocks larger 256 bytes')
   const padLength = blocksize - (messageLength % blocksize)
-  if (padLength < blocksize) {
-    return Buffer.alloc(padLength, new Uint8Array([padLength]))
-  } else {
-    return Buffer.from('')
-  }
+  return Buffer.alloc(padLength, new Uint8Array([padLength]))
 }
 
 function unpad (padded, blocksize) {

--- a/test/pkcs7.test.js
+++ b/test/pkcs7.test.js
@@ -33,14 +33,14 @@ describe('pkcs#7', function () {
       assert.deepStrictEqual(padded, Buffer.from(new Uint8Array([97, 97, 97, 97, 97, 97, 2, 2])))
     })
 
-    it('shall not pad if block size fits', function () {
+    it('shall pad if block size fits', function () {
       const b = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0])
       const padded = Buffer.concat([
         b,
         pad(b.length, 8)
       ])
-      assert.strictEqual(padded.length, 8)
-      assert.deepStrictEqual(padded, Buffer.from(b))
+      assert.strictEqual(padded.length, 16)
+      assert.deepStrictEqual(padded, Buffer.from(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8, 8, 8, 8, 8])))
     })
   })
 


### PR DESCRIPTION
ansible-vault expect data to always be padded, even if data fits.

This fixes a bug where ansible is unable to decode secrets encrypted with this library if they have a length that is a multiple of 16.